### PR TITLE
Fix sign s should compared with nh.

### DIFF
--- a/src/Signature/Signer.php
+++ b/src/Signature/Signer.php
@@ -76,7 +76,7 @@ class Signer
             $math = $this->adapter;
             $nh = $math->rightShift($options['n'], 1);
 
-            if ($math->cmp($options['n'], $nh) > 0) {
+            if ($math->cmp($s, $nh) > 0) {
                 $s = gmp_sub($options['n'], $s);
             }
         }

--- a/test/unit/Secp256k1Test.php
+++ b/test/unit/Secp256k1Test.php
@@ -47,6 +47,11 @@ class Secp256k1Test extends TestCase
 
         $this->assertEquals('f67118680df5993e8efca4d3ecc4172ca4ac5e3e007ea774293e373864809703', gmp_strval($signature->getR(), 16));
         $this->assertEquals('47427f3633371c1a30abbb2b717dbd78ef63d5b19b5a951f9d681cccdd520320', gmp_strval($signature->getS(), 16));
+
+        $signature = $this->secp256k1->sign('710aee292b0f1749aaa0cfef67111e2f716afbdb475e7f250bdb80c6655b0a66', $this->testPrivateKey);
+
+        $this->assertEquals('8d8bfd01c48454b5b3fed2361cbd0e8c3282d5bd2e26762e4c9dfbe1ef35f325', gmp_strval($signature->getR(), 16));
+        $this->assertEquals('6d6a5dc397934b5544835f34ff24263cbc00bdd516b6f0df3f29cdf6c779ccfb', gmp_strval($signature->getS(), 16));
     }
 
     /**


### PR DESCRIPTION
Fix sign s should compared with nh.

It will return wrong s sometimes.